### PR TITLE
Implement interactive search filters

### DIFF
--- a/Mocar-iOS/Features/Search/AreaFilterView.swift
+++ b/Mocar-iOS/Features/Search/AreaFilterView.swift
@@ -8,34 +8,16 @@
 import SwiftUI
 
 struct AreaFilterView: View {
-    @State private var fuels: [CheckableItem] = [
-        CheckableItem(name: "서울", checked: false),
-        CheckableItem(name: "인천", checked: false),
-        CheckableItem(name: "대전", checked: false),
-        CheckableItem(name: "대구", checked: false),
-        CheckableItem(name: "광주", checked: false),
-        CheckableItem(name: "부산", checked: false),
-        CheckableItem(name: "울산", checked: false),
-        CheckableItem(name: "세종", checked: false),
-        CheckableItem(name: "경기", checked: false),
-        CheckableItem(name: "강원", checked: false),
-        CheckableItem(name: "경남", checked: false),
-        CheckableItem(name: "경북", checked: false),
-        CheckableItem(name: "전남", checked: false),
-        CheckableItem(name: "전북", checked: false),
-        CheckableItem(name: "충남", checked: false),
-        CheckableItem(name: "충북", checked: false),
-        CheckableItem(name: "제주", checked: false),
-    ]
-    
+    @Binding var regions: [CheckableItem]
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("지역")
                     .font(.headline)
                     .padding(.bottom, 10)
-                ForEach(fuels.indices, id: \.self) { idx in
-                    CheckOptionsRow(item: $fuels[idx])
+                ForEach($regions) { $item in
+                    CheckOptionsRow(item: $item)
                     Divider()
                 }
             }

--- a/Mocar-iOS/Features/Search/BrandFilterView.swift
+++ b/Mocar-iOS/Features/Search/BrandFilterView.swift
@@ -1,5 +1,5 @@
 //
-//  BrandView.swift
+//  BrandFilterView.swift
 //  Mocar-iOS
 //
 //  Created by wj on 9/17/25.
@@ -8,39 +8,78 @@
 import SwiftUI
 
 struct BrandView: View {
-    
-    struct Maker: Identifiable {
-        let id = UUID()
-        let name: String
-        let count: Int
-        let imageName: String
-    }
-    
-    private let makers: [Maker] = [
-        Maker(name: "현대", count: 49355, imageName: "hyundai 1"),
-        Maker(name: "제네시스", count: 7381, imageName: "genesis"),
-        Maker(name: "기아", count: 41936, imageName: "kia"),
-        Maker(name: "르노코리아", count: 7728, imageName: "renault"),
-        Maker(name: "쉐보레", count: 8362, imageName: "chevrolet"),
-        Maker(name: "벤츠", count: 8413, imageName: "benz"),
-        Maker(name: "BMW", count: 8362, imageName: "bmw"),
-        Maker(name: "아우디", count: 8362, imageName: "audi"),
-        Maker(name: "테슬라", count: 8362, imageName: "tesla"),
-        Maker(name: "페라리", count: 8362, imageName: "ferrari"),
-    ]
-    
+    @ObservedObject var viewModel: SearchViewModel
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("제조사")
                     .font(.headline)
                     .padding(.bottom, 10)
-                ForEach(makers) { maker in
-                    BrandOptionsRow(maker: maker)
+
+                ForEach(viewModel.brands) { brand in
+                    VStack(spacing: 0) {
+                        BrandOptionsRow(
+                            brand: brand,
+                            count: viewModel.count(for: brand.key),
+                            isSelected: viewModel.isBrandSelected(brand.key),
+                            isExpanded: viewModel.expandedBrandKey == brand.key,
+                            onToggleSelection: {
+                                viewModel.toggleBrandSelection(brand.key)
+                            },
+                            onToggleExpansion: {
+                                viewModel.toggleBrandExpansion(brand.key)
+                            }
+                        )
+
+                        if viewModel.expandedBrandKey == brand.key {
+                            let models = viewModel.models(for: brand.key)
+                            if models.isEmpty {
+                                Text("등록된 차종이 없습니다.")
+                                    .font(.footnote)
+                                    .foregroundColor(.gray)
+                                    .padding(.vertical, 8)
+                                    .padding(.leading, 44)
+                            } else {
+                                ForEach(models, id: \.self) { model in
+                                    BrandModelRow(
+                                        model: model,
+                                        isSelected: viewModel.isModelSelected(model, for: brand.key),
+                                        onToggle: {
+                                            viewModel.toggleModelSelection(model, for: brand.key)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+
+                        Divider()
+                    }
                 }
             }
             .padding(.top, 20)
             .padding(.horizontal)
         }
+    }
+}
+
+private struct BrandModelRow: View {
+    let model: String
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isSelected ? Color.accentColor : Color(.systemGray3))
+                Text(model)
+                    .foregroundColor(.black)
+                Spacer()
+            }
+            .frame(height: 44)
+            .padding(.leading, 32)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Mocar-iOS/Features/Search/CarSizeFilterView.swift
+++ b/Mocar-iOS/Features/Search/CarSizeFilterView.swift
@@ -8,28 +8,16 @@
 import SwiftUI
 
 struct CarSizeFilterView: View {
-    @State private var fuels: [CheckableItem] = [
-        CheckableItem(name: "경차", checked: false),
-        CheckableItem(name: "소형", checked: false),
-        CheckableItem(name: "준중형", checked: false),
-        CheckableItem(name: "중형", checked: false),
-        CheckableItem(name: "대형", checked: false),
-        CheckableItem(name: "스포츠카", checked: false),
-        CheckableItem(name: "SUV", checked: false),
-        CheckableItem(name: "RV", checked: false),
-        CheckableItem(name: "승합", checked: false),
-        CheckableItem(name: "트럭", checked: false),
-        CheckableItem(name: "버스", checked: false)
-    ]
-    
+    @Binding var carTypes: [CheckableItem]
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("차종")
                     .font(.headline)
                     .padding(.bottom, 10)
-                ForEach(fuels.indices, id: \.self) { idx in
-                    CheckOptionsRow(item: $fuels[idx])
+                ForEach($carTypes) { $item in
+                    CheckOptionsRow(item: $item)
                     Divider()
                 }
             }

--- a/Mocar-iOS/Features/Search/FuelFilterView.swift
+++ b/Mocar-iOS/Features/Search/FuelFilterView.swift
@@ -8,22 +8,16 @@
 import SwiftUI
 
 struct FuelFilterView: View {
-    @State private var fuels: [CheckableItem] = [
-        CheckableItem(name: "가솔린(휘발유)", checked: false),
-        CheckableItem(name: "디젤(경유)", checked: false),
-        CheckableItem(name: "전기", checked: false),
-        CheckableItem(name: "LPG", checked: false),
-        CheckableItem(name: "하이브리드", checked: false)
-    ]
-    
+    @Binding var fuels: [CheckableItem]
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("연료")
                     .font(.headline)
                     .padding(.bottom, 10)
-                ForEach(fuels.indices, id: \.self) { idx in
-                    CheckOptionsRow(item: $fuels[idx])
+                ForEach($fuels) { $item in
+                    CheckOptionsRow(item: $item)
                     Divider()
                 }
             }

--- a/Mocar-iOS/Features/Search/LeftCategoryView.swift
+++ b/Mocar-iOS/Features/Search/LeftCategoryView.swift
@@ -8,16 +8,16 @@
 import SwiftUI
 
 struct LeftCategoryView: View {
-    let categories: [String]
-    @Binding var selectedCategory: String?
-    
+    let categories: [SearchCategory]
+    @Binding var selectedCategory: SearchCategory
+
     var body: some View {
         VStack(spacing: 0) {
-            ForEach(categories, id: \.self) { category in
+            ForEach(categories) { category in
                 Button(action: {
                     selectedCategory = category
                 }) {
-                    Text(category)
+                    Text(category.title)
                         .fontWeight(selectedCategory == category ? .bold : .regular)
                         .foregroundColor(selectedCategory == category ? .black : .gray)
                         .frame(maxWidth: .infinity, minHeight: 50)
@@ -25,6 +25,7 @@ struct LeftCategoryView: View {
                             selectedCategory == category ? Color.white : Color(UIColor.systemGray6)
                         )
                 }
+                .buttonStyle(.plain)
                 .contentShape(Rectangle())
             }
             Spacer()
@@ -33,4 +34,3 @@ struct LeftCategoryView: View {
         .background(Color(UIColor.systemGray6))
     }
 }
-

--- a/Mocar-iOS/Features/Search/MileageFilterView.swift
+++ b/Mocar-iOS/Features/Search/MileageFilterView.swift
@@ -10,18 +10,18 @@ import SwiftUI
 struct MileageFilterView: View {
     @Binding var minMileage: Int
     @Binding var maxMileage: Int
-    
+
     @State private var minText: String = ""
     @State private var maxText: String = ""
-    
+
     private let mileageRange: ClosedRange<Int> = 0...200000
-    
+
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 20) {
                 Text("주행거리")
                     .font(.headline)
-                
+
                 // 슬라이더: Int ↔ Double 변환
                 RangeSlider(
                     lowerValue: Binding(
@@ -50,34 +50,40 @@ struct MileageFilterView: View {
                     .keyboardType(.numberPad)
                     .padding(10)
                     .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
-                    .onChange(of: minText) {
-                        minText = minText.filter { "0123456789".contains($0) }
-                        if let value = Int(minText) {
+                    .onChange(of: minText) { newValue in
+                        let filtered = newValue.filter { "0123456789".contains($0) }
+                        if filtered != newValue {
+                            minText = filtered
+                        }
+                        if let value = Int(filtered) {
                             minMileage = min(max(value, mileageRange.lowerBound), maxMileage)
                         }
                     }
                     .onSubmit {
                         minText = String(minMileage)
                     }
-                
+
                 Text("km")
-                
+
                 Spacer()
-                
+
                 TextField("최대", text: $maxText)
                     .keyboardType(.numberPad)
                     .padding(10)
                     .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
-                    .onChange(of: maxText) {
-                        maxText = maxText.filter { "0123456789".contains($0) }
-                        if let value = Int(maxText) {
+                    .onChange(of: maxText) { newValue in
+                        let filtered = newValue.filter { "0123456789".contains($0) }
+                        if filtered != newValue {
+                            maxText = filtered
+                        }
+                        if let value = Int(filtered) {
                             maxMileage = max(min(value, mileageRange.upperBound), minMileage)
                         }
                     }
                     .onSubmit {
                         maxText = String(maxMileage)
                     }
-                
+
                 Text("km")
             }
         }
@@ -85,6 +91,18 @@ struct MileageFilterView: View {
         .onAppear {
             minText = String(minMileage)
             maxText = String(maxMileage)
+        }
+        .onChange(of: minMileage) { newValue in
+            let value = String(newValue)
+            if minText != value {
+                minText = value
+            }
+        }
+        .onChange(of: maxMileage) { newValue in
+            let value = String(newValue)
+            if maxText != value {
+                maxText = value
+            }
         }
         Spacer()
     }

--- a/Mocar-iOS/Features/Search/PriceFilterView.swift
+++ b/Mocar-iOS/Features/Search/PriceFilterView.swift
@@ -10,18 +10,18 @@ import SwiftUI
 struct PriceFilterView: View {
     @Binding var minPrice: Int
     @Binding var maxPrice: Int
-    
+
     @State private var minText: String = ""
     @State private var maxText: String = ""
-    
+
     private let priceRange: ClosedRange<Int> = 0...10000
-    
+
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 20) {
                 Text("가격")
                     .font(.headline)
-                
+
                 // 슬라이더: Int ↔ Double 변환
                 RangeSlider(
                     lowerValue: Binding(
@@ -50,34 +50,40 @@ struct PriceFilterView: View {
                     .keyboardType(.numberPad)
                     .padding(10)
                     .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
-                    .onChange(of: minText) {
-                        minText = minText.filter { "0123456789".contains($0) }
-                        if let value = Int(minText) {
+                    .onChange(of: minText) { newValue in
+                        let filtered = newValue.filter { "0123456789".contains($0) }
+                        if filtered != newValue {
+                            minText = filtered
+                        }
+                        if let value = Int(filtered) {
                             minPrice = min(max(value, priceRange.lowerBound), maxPrice)
                         }
                     }
                     .onSubmit {
                         minText = String(minPrice)
                     }
-                
+
                 Text("만원")
-                
+
                 Spacer()
-                
+
                 TextField("최대", text: $maxText)
                     .keyboardType(.numberPad)
                     .padding(10)
                     .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
-                    .onChange(of: maxText) {
-                        maxText = maxText.filter { "0123456789".contains($0) }
-                        if let value = Int(maxText) {
+                    .onChange(of: maxText) { newValue in
+                        let filtered = newValue.filter { "0123456789".contains($0) }
+                        if filtered != newValue {
+                            maxText = filtered
+                        }
+                        if let value = Int(filtered) {
                             maxPrice = max(min(value, priceRange.upperBound), minPrice)
                         }
                     }
                     .onSubmit {
                         maxText = String(maxPrice)
                     }
-                
+
                 Text("만원")
             }
         }
@@ -85,6 +91,18 @@ struct PriceFilterView: View {
         .onAppear {
             minText = String(minPrice)
             maxText = String(maxPrice)
+        }
+        .onChange(of: minPrice) { newValue in
+            let value = String(newValue)
+            if minText != value {
+                minText = value
+            }
+        }
+        .onChange(of: maxPrice) { newValue in
+            let value = String(newValue)
+            if maxText != value {
+                maxText = value
+            }
         }
         Spacer()
     }

--- a/Mocar-iOS/Features/Search/RightOptionView.swift
+++ b/Mocar-iOS/Features/Search/RightOptionView.swift
@@ -8,30 +8,25 @@
 import SwiftUI
 
 struct RightOptionView: View {
-    @Binding var selectedCategory: String?
-    @Binding var minPrice: Int
-    @Binding var maxPrice: Int
-    @Binding var minYear: Int
-    @Binding var maxYear: Int
-    @Binding var minMileage: Int
-    @Binding var maxMileage: Int
-    
+    @ObservedObject var viewModel: SearchViewModel
+
     var body: some View {
         VStack {
-            if selectedCategory == "제조사" {
-                BrandView()
-            } else if selectedCategory == "가격" {
-                PriceFilterView(minPrice: $minPrice, maxPrice: $maxPrice)
-            } else if selectedCategory == "연식" {
-                YearFilterView(minYear: $minYear, maxYear: $maxYear)
-            } else if selectedCategory == "주행거리" {
-                MileageFilterView(minMileage: $minMileage, maxMileage: $maxMileage)
-            } else if selectedCategory == "차종" {
-                CarSizeFilterView()
-            } else if selectedCategory == "연료" {
-                FuelFilterView()
-            } else if selectedCategory == "지역" {
-                AreaFilterView()
+            switch viewModel.selectedCategory {
+            case .brand:
+                BrandView(viewModel: viewModel)
+            case .price:
+                PriceFilterView(minPrice: $viewModel.minPrice, maxPrice: $viewModel.maxPrice)
+            case .year:
+                YearFilterView(minYear: $viewModel.minYear, maxYear: $viewModel.maxYear)
+            case .mileage:
+                MileageFilterView(minMileage: $viewModel.minMileage, maxMileage: $viewModel.maxMileage)
+            case .bodyType:
+                CarSizeFilterView(carTypes: $viewModel.carTypeOptions)
+            case .fuel:
+                FuelFilterView(fuels: $viewModel.fuelOptions)
+            case .region:
+                AreaFilterView(regions: $viewModel.regionOptions)
             }
         }
         .frame(maxWidth: .infinity)

--- a/Mocar-iOS/Features/Search/SearchView.swift
+++ b/Mocar-iOS/Features/Search/SearchView.swift
@@ -8,19 +8,8 @@
 import SwiftUI
 
 struct SearchView: View {
-    @State private var searchText = ""
-    @State private var selectedCategory: String? = "제조사"
-    @State private var minPrice: Int = 0
-    @State private var maxPrice: Int = 10000
-    
-    @State private var minYear: Int = Calendar.current.component(.year, from: Date()) - 20
-    @State private var maxYear: Int = Calendar.current.component(.year, from: Date())
-    
-    @State private var minMileage: Int = 0
-    @State private var maxMileage: Int = 200000
-    
-    let categories = ["제조사", "가격", "연식", "주행거리", "차종", "연료", "지역"]
-    
+    @StateObject private var viewModel = SearchViewModel()
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -31,8 +20,10 @@ struct SearchView: View {
                             .font(.title2)
                             .foregroundColor(.black)
                     }
-                    
-                    TextField("모델, 차량번호, 판매자를 검색해보세요", text: $searchText)
+
+                    TextField("모델, 차량번호, 판매자를 검색해보세요", text: $viewModel.searchText)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
                         .padding(10)
                         .background(
                             RoundedRectangle(cornerRadius: 8)
@@ -40,7 +31,7 @@ struct SearchView: View {
                         )
                 }
                 .padding(.horizontal)
-                
+
                 // 최근검색기록
                 HStack {
                     Spacer()
@@ -51,31 +42,32 @@ struct SearchView: View {
                         .foregroundColor(.gray)
                 }
                 .padding()
-                
+
                 Divider()
-                
+
                 // 메인 검색영역
                 HStack(spacing: 0) {
-                    LeftCategoryView(categories: categories, selectedCategory: $selectedCategory)
+                    LeftCategoryView(categories: viewModel.categories, selectedCategory: $viewModel.selectedCategory)
                     Divider()
-                    RightOptionView(
-                        selectedCategory: $selectedCategory,
-                        minPrice: $minPrice,
-                        maxPrice: $maxPrice,
-                        minYear: $minYear,
-                        maxYear: $maxYear,
-                        minMileage: $minMileage,
-                        maxMileage: $maxMileage,
-                    )
+                    RightOptionView(viewModel: viewModel)
                 }
-                
+
+                Divider()
+
+                // 결과 요약
+                HStack {
+                    Text("검색 결과 \(viewModel.filteredListings.count)대")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    Spacer()
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+
                 // 하단 버튼
                 HStack(spacing: 12) {
                     Button(action: {
-                        selectedCategory = "제조사"
-                        searchText = ""
-                        minPrice = 0
-                        maxPrice = 10000
+                        viewModel.resetFilters()
                     }) {
                         Text("초기화")
                             .fontWeight(.bold)
@@ -89,9 +81,9 @@ struct SearchView: View {
                                     .stroke(Color.black, lineWidth: 1)
                             )
                     }
-                    
+
                     Button(action: {}) {
-                        Text("156,973대 보기")
+                        Text("\(viewModel.filteredListings.count)대 보기")
                             .fontWeight(.bold)
                             .frame(height: 50)
                             .frame(maxWidth: .infinity)

--- a/Mocar-iOS/Features/Search/SearchViewModel.swift
+++ b/Mocar-iOS/Features/Search/SearchViewModel.swift
@@ -1,0 +1,276 @@
+import SwiftUI
+
+enum SearchCategory: String, CaseIterable, Identifiable {
+    case brand = "제조사"
+    case price = "가격"
+    case year = "연식"
+    case mileage = "주행거리"
+    case bodyType = "차종"
+    case fuel = "연료"
+    case region = "지역"
+
+    var id: String { rawValue }
+
+    var title: String { rawValue }
+}
+
+final class SearchViewModel: ObservableObject {
+    struct BrandInfo: Identifiable, Hashable {
+        let id = UUID()
+        let key: String
+        let displayName: String
+        let imageName: String?
+    }
+
+    @Published var searchText: String = ""
+    @Published var selectedCategory: SearchCategory = .brand
+
+    @Published var minPrice: Int = 0
+    @Published var maxPrice: Int = 10000
+
+    @Published var minYear: Int
+    @Published var maxYear: Int
+
+    @Published var minMileage: Int = 0
+    @Published var maxMileage: Int = 200000
+
+    @Published private(set) var selectedBrandKeys: Set<String> = []
+    @Published var expandedBrandKey: String?
+    @Published private var selectedModelsByBrand: [String: Set<String>] = [:]
+
+    @Published var carTypeOptions: [CheckableItem]
+    @Published var fuelOptions: [CheckableItem]
+    @Published var regionOptions: [CheckableItem]
+
+    private let listings: [Listing]
+    private let brandInfos: [BrandInfo] = [
+        BrandInfo(key: "Hyundai", displayName: "현대", imageName: "hyundai 1"),
+        BrandInfo(key: "Genesis", displayName: "제네시스", imageName: "genesis"),
+        BrandInfo(key: "Kia", displayName: "기아", imageName: "kia"),
+        BrandInfo(key: "Renault", displayName: "르노코리아", imageName: "renault"),
+        BrandInfo(key: "Chevrolet", displayName: "쉐보레", imageName: "chevrolet"),
+        BrandInfo(key: "Mercedes-Benz", displayName: "벤츠", imageName: "benz"),
+        BrandInfo(key: "BMW", displayName: "BMW", imageName: "bmw"),
+        BrandInfo(key: "Audi", displayName: "아우디", imageName: "audi"),
+        BrandInfo(key: "Tesla", displayName: "테슬라", imageName: "tesla"),
+        BrandInfo(key: "Ferrari", displayName: "페라리", imageName: "ferrari")
+    ]
+
+    private let fuelDisplayToRaw: [String: String] = [
+        "가솔린(휘발유)": "Gasoline",
+        "디젤(경유)": "Diesel",
+        "전기": "Electric",
+        "LPG": "LPG",
+        "하이브리드": "Hybrid"
+    ]
+
+    private let carTypeMapping: [String: String] = [
+        "488 GTB": "스포츠카",
+        "M3": "스포츠카",
+        "Sonata": "중형",
+        "A6": "중형",
+        "Model 3": "중형"
+    ]
+
+    private let yearRange: ClosedRange<Int>
+    private let priceRange: ClosedRange<Int> = 0...10000
+    private let mileageRange: ClosedRange<Int> = 0...200000
+
+    init(listings: [Listing] = Listing.listingData) {
+        self.listings = listings
+
+        let currentYear = Calendar.current.component(.year, from: Date())
+        yearRange = 2006...currentYear
+        minYear = yearRange.lowerBound
+        maxYear = yearRange.upperBound
+
+        carTypeOptions = SearchViewModel.defaultCarTypes
+        fuelOptions = SearchViewModel.defaultFuelOptions
+        regionOptions = SearchViewModel.defaultRegionOptions
+    }
+
+    var categories: [SearchCategory] {
+        SearchCategory.allCases
+    }
+
+    var brands: [BrandInfo] {
+        brandInfos.sorted { lhs, rhs in
+            let lhsCount = count(for: lhs.key)
+            let rhsCount = count(for: rhs.key)
+            if lhsCount == rhsCount {
+                return lhs.displayName < rhs.displayName
+            }
+            return lhsCount > rhsCount
+        }
+    }
+
+    var filteredListings: [Listing] {
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedQuery = trimmedQuery.lowercased()
+        let activeBrandKeys = selectedBrandKeys
+        let selectedModels = selectedModelsByBrand
+        let selectedCarTypes = Set(carTypeOptions.filter { $0.checked }.map { $0.name })
+        let selectedFuels = Set(fuelOptions.compactMap { item -> String? in
+            guard item.checked else { return nil }
+            return fuelDisplayToRaw[item.name]
+        })
+        let selectedRegions = Set(regionOptions.filter { $0.checked }.map { $0.name })
+
+        return listings.filter { listing in
+            if !normalizedQuery.isEmpty {
+                if !listing.title.lowercased().contains(normalizedQuery) &&
+                    !listing.brand.lowercased().contains(normalizedQuery) &&
+                    !listing.model.lowercased().contains(normalizedQuery) &&
+                    !listing.plateNumber.lowercased().contains(normalizedQuery) {
+                    return false
+                }
+            }
+
+            if listing.price < minPrice || listing.price > maxPrice { return false }
+            if listing.year < minYear || listing.year > maxYear { return false }
+            if listing.mileage < minMileage || listing.mileage > maxMileage { return false }
+
+            if !activeBrandKeys.isEmpty {
+                guard activeBrandKeys.contains(listing.brand) else { return false }
+                if let models = selectedModels[listing.brand], !models.isEmpty {
+                    guard models.contains(listing.model) else { return false }
+                }
+            } else if let models = selectedModels[listing.brand], !models.isEmpty {
+                guard models.contains(listing.model) else { return false }
+            }
+
+            if !selectedCarTypes.isEmpty {
+                guard let carType = carTypeMapping[listing.model], selectedCarTypes.contains(carType) else { return false }
+            }
+
+            if !selectedFuels.isEmpty && !selectedFuels.contains(listing.fuel) { return false }
+
+            if !selectedRegions.isEmpty && !selectedRegions.contains(listing.region) { return false }
+
+            return true
+        }
+    }
+
+    func count(for brandKey: String) -> Int {
+        listings.filter { $0.brand == brandKey }.count
+    }
+
+    func models(for brandKey: String) -> [String] {
+        let models = listings
+            .filter { $0.brand == brandKey }
+            .map { $0.model }
+        return Array(Set(models)).sorted()
+    }
+
+    func isBrandSelected(_ brandKey: String) -> Bool {
+        selectedBrandKeys.contains(brandKey)
+    }
+
+    func toggleBrandSelection(_ brandKey: String) {
+        if selectedBrandKeys.contains(brandKey) {
+            selectedBrandKeys.remove(brandKey)
+            selectedModelsByBrand.removeValue(forKey: brandKey)
+        } else {
+            selectedBrandKeys.insert(brandKey)
+        }
+    }
+
+    func toggleBrandExpansion(_ brandKey: String) {
+        if expandedBrandKey == brandKey {
+            expandedBrandKey = nil
+        } else {
+            expandedBrandKey = brandKey
+        }
+    }
+
+    func isModelSelected(_ model: String, for brandKey: String) -> Bool {
+        selectedModelsByBrand[brandKey]?.contains(model) ?? false
+    }
+
+    func toggleModelSelection(_ model: String, for brandKey: String) {
+        var models = selectedModelsByBrand[brandKey] ?? []
+        if models.contains(model) {
+            models.remove(model)
+        } else {
+            models.insert(model)
+            selectedBrandKeys.insert(brandKey)
+        }
+        if models.isEmpty {
+            selectedModelsByBrand.removeValue(forKey: brandKey)
+        } else {
+            selectedModelsByBrand[brandKey] = models
+        }
+    }
+
+    func resetFilters() {
+        searchText = ""
+        selectedCategory = .brand
+
+        minPrice = priceRange.lowerBound
+        maxPrice = priceRange.upperBound
+
+        minYear = yearRange.lowerBound
+        maxYear = yearRange.upperBound
+
+        minMileage = mileageRange.lowerBound
+        maxMileage = mileageRange.upperBound
+
+        selectedBrandKeys.removeAll()
+        expandedBrandKey = nil
+        selectedModelsByBrand.removeAll()
+
+        carTypeOptions = SearchViewModel.defaultCarTypes
+        fuelOptions = SearchViewModel.defaultFuelOptions
+        regionOptions = SearchViewModel.defaultRegionOptions
+    }
+}
+
+private extension SearchViewModel {
+    static var defaultCarTypes: [CheckableItem] {
+        [
+            CheckableItem(name: "경차", checked: false),
+            CheckableItem(name: "소형", checked: false),
+            CheckableItem(name: "준중형", checked: false),
+            CheckableItem(name: "중형", checked: false),
+            CheckableItem(name: "대형", checked: false),
+            CheckableItem(name: "스포츠카", checked: false),
+            CheckableItem(name: "SUV", checked: false),
+            CheckableItem(name: "RV", checked: false),
+            CheckableItem(name: "승합", checked: false),
+            CheckableItem(name: "트럭", checked: false),
+            CheckableItem(name: "버스", checked: false)
+        ]
+    }
+
+    static var defaultFuelOptions: [CheckableItem] {
+        [
+            CheckableItem(name: "가솔린(휘발유)", checked: false),
+            CheckableItem(name: "디젤(경유)", checked: false),
+            CheckableItem(name: "전기", checked: false),
+            CheckableItem(name: "LPG", checked: false),
+            CheckableItem(name: "하이브리드", checked: false)
+        ]
+    }
+
+    static var defaultRegionOptions: [CheckableItem] {
+        [
+            CheckableItem(name: "서울", checked: false),
+            CheckableItem(name: "인천", checked: false),
+            CheckableItem(name: "대전", checked: false),
+            CheckableItem(name: "대구", checked: false),
+            CheckableItem(name: "광주", checked: false),
+            CheckableItem(name: "부산", checked: false),
+            CheckableItem(name: "울산", checked: false),
+            CheckableItem(name: "세종", checked: false),
+            CheckableItem(name: "경기", checked: false),
+            CheckableItem(name: "강원", checked: false),
+            CheckableItem(name: "경남", checked: false),
+            CheckableItem(name: "경북", checked: false),
+            CheckableItem(name: "전남", checked: false),
+            CheckableItem(name: "전북", checked: false),
+            CheckableItem(name: "충남", checked: false),
+            CheckableItem(name: "충북", checked: false),
+            CheckableItem(name: "제주", checked: false)
+        ]
+    }
+}

--- a/Mocar-iOS/Features/Search/YearFilterView.swift
+++ b/Mocar-iOS/Features/Search/YearFilterView.swift
@@ -10,18 +10,18 @@ import SwiftUI
 struct YearFilterView: View {
     @Binding var minYear: Int
     @Binding var maxYear: Int
-    
+
     @State private var minText: String = ""
     @State private var maxText: String = ""
-    
+
     private let yearRange: ClosedRange<Int> = 2006...Calendar.current.component(.year, from: Date())
-    
+
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 20) {
                 Text("연식")
                     .font(.headline)
-                
+
                 // 슬라이더: Int ↔ Double 변환
                 RangeSlider(
                     lowerValue: Binding(
@@ -50,34 +50,40 @@ struct YearFilterView: View {
                     .keyboardType(.numberPad)
                     .padding(10)
                     .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
-                    .onChange(of: minText) {
-                        minText = minText.filter { "0123456789".contains($0) }
-                        if let value = Int(minText) {
+                    .onChange(of: minText) { newValue in
+                        let filtered = newValue.filter { "0123456789".contains($0) }
+                        if filtered != newValue {
+                            minText = filtered
+                        }
+                        if let value = Int(filtered) {
                             minYear = min(max(value, yearRange.lowerBound), maxYear)
                         }
                     }
                     .onSubmit {
                         minText = String(minYear)
                     }
-                
+
                 Text("년")
-                
+
                 Spacer()
-                
+
                 TextField("최대", text: $maxText)
                     .keyboardType(.numberPad)
                     .padding(10)
                     .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
-                    .onChange(of: maxText) {
-                        maxText = maxText.filter { "0123456789".contains($0) }
-                        if let value = Int(maxText) {
+                    .onChange(of: maxText) { newValue in
+                        let filtered = newValue.filter { "0123456789".contains($0) }
+                        if filtered != newValue {
+                            maxText = filtered
+                        }
+                        if let value = Int(filtered) {
                             maxYear = max(min(value, yearRange.upperBound), minYear)
                         }
                     }
                     .onSubmit {
                         maxText = String(maxYear)
                     }
-                
+
                 Text("년")
             }
         }
@@ -85,6 +91,18 @@ struct YearFilterView: View {
         .onAppear {
             minText = String(minYear)
             maxText = String(maxYear)
+        }
+        .onChange(of: minYear) { newValue in
+            let value = String(newValue)
+            if minText != value {
+                minText = value
+            }
+        }
+        .onChange(of: maxYear) { newValue in
+            let value = String(newValue)
+            if maxText != value {
+                maxText = value
+            }
         }
         Spacer()
     }

--- a/Mocar-iOS/Shared/Components/BrandOptionsRow.swift
+++ b/Mocar-iOS/Shared/Components/BrandOptionsRow.swift
@@ -1,5 +1,5 @@
 //
-//  OptionsRow.swift
+//  BrandOptionsRow.swift
 //  Mocar-iOS
 //
 //  Created by wj on 9/16/25.
@@ -8,28 +8,45 @@
 import SwiftUI
 
 struct BrandOptionsRow: View {
-    let maker: BrandView.Maker
-    
+    let brand: SearchViewModel.BrandInfo
+    let count: Int
+    let isSelected: Bool
+    let isExpanded: Bool
+    let onToggleSelection: () -> Void
+    let onToggleExpansion: () -> Void
+
     var body: some View {
-        HStack {
-            Image(maker.imageName)
-                .resizable()
-                .frame(width: 28, height: 28)
-                .foregroundColor(.gray)
-            
-            Text(maker.name)
-                .foregroundColor(.black)
-            
+        HStack(spacing: 12) {
+            Button(action: onToggleSelection) {
+                HStack(spacing: 12) {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(isSelected ? Color.accentColor : Color(.systemGray3))
+
+                    if let imageName = brand.imageName {
+                        Image(imageName)
+                            .resizable()
+                            .frame(width: 28, height: 28)
+                    }
+
+                    Text(brand.displayName)
+                        .foregroundColor(.black)
+                }
+            }
+            .buttonStyle(.plain)
+
             Spacer()
-            
-            Text("\(maker.count)")
+
+            Text("\(count)")
                 .foregroundColor(.gray)
                 .font(.subheadline)
-            
-            Image(systemName: "chevron.right")
-                .foregroundColor(.gray)
+
+            Button(action: onToggleExpansion) {
+                Image(systemName: "chevron.right")
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .foregroundColor(.gray)
+            }
+            .buttonStyle(.plain)
         }
         .frame(height: 50)
-        Divider()
     }
 }

--- a/Mocar-iOS/Shared/Components/CheckOptionsRow.swift
+++ b/Mocar-iOS/Shared/Components/CheckOptionsRow.swift
@@ -16,7 +16,7 @@ struct CheckableItem: Identifiable {
 
 struct CheckOptionsRow: View {
     @Binding var item: CheckableItem
-    
+
     var body: some View {
         Button(action: {
             item.checked.toggle() // 클릭하면 체크 상태 토글
@@ -25,7 +25,7 @@ struct CheckOptionsRow: View {
                 // 체크 아이콘
                 Image(systemName: item.checked ? "checkmark.circle.fill" : "circle")
                     .foregroundColor(item.checked ? Color.accentColor : Color(.systemGray3))
-                
+
                 // 항목 이름
                 Text(item.name)
                     .foregroundColor(.black)
@@ -33,5 +33,7 @@ struct CheckOptionsRow: View {
             }
             .frame(height: 50)
         }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `SearchViewModel` to manage filter state, brand/model selections, and filtered listings
- rework the search screen to bind UI elements to the shared view model and surface the current result count
- enable multi-select filters, synchronized checkboxes, and expandable brand-to-model pickers across the search options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca601cd9f48324a711c55c8d42a8a4