### PR TITLE
feat: 바텀바 항상 노출되도록 변경, 로그인하지 않고 바텀바의 마이페이지,채팅 페이지 클릭시 로그인 필요 모달 노출

### DIFF
--- a/Mocar-iOS/Features/Auth/Views/LoginView.swift
+++ b/Mocar-iOS/Features/Auth/Views/LoginView.swift
@@ -25,8 +25,8 @@ struct LoginView: View {
     }
     
     var body: some View {
-        NavigationStack{
-            VStack(spacing: 20) {
+        VStack(spacing: 20) {
+            TopBar(style: .login)
                 Spacer().frame(height: 80)
                 
                 Text("로그인")
@@ -164,8 +164,8 @@ struct LoginView: View {
                 .font(.footnote)
             }
             .padding(.top)
-            
-        }
+            .navigationBarBackButtonHidden(true) 
+ 
     }
     
     // MARK: - Firebase 로그인 함수

--- a/Mocar-iOS/Mocar_iOSApp.swift
+++ b/Mocar-iOS/Mocar_iOSApp.swift
@@ -20,13 +20,8 @@ struct Mocar_iOSApp: App {
     }
     var body: some Scene {
         WindowGroup {
-
-            if userSession.user != nil {
-                
-                BottomBar()  // 이미 로그인 되어 있으면 메인 뷰(ContentView로 대체)
-            } else {
-                HomeView()   // 로그인 안 되어 있으면 로그인 화면
-            }
+            BottomBar()
+                .environmentObject(userSession)
         }
     }
 

--- a/Mocar-iOS/Shared/Components/Layout/BottomBar.swift
+++ b/Mocar-iOS/Shared/Components/Layout/BottomBar.swift
@@ -10,57 +10,92 @@ import SwiftUI
 struct BottomBar: View {
     @State private var selectedTab: Int = 0
     
-    @StateObject var session = UserSession()
+    @EnvironmentObject var session: UserSession //전역 세션 받아오기
+    @State private var showLoginModal = false
+     @State private var navigateToLogin = false
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            // 메인 콘텐츠
-            TabView(selection: $selectedTab) {
+        NavigationStack{
+            ZStack(alignment: .bottom) {
+                // 메인 콘텐츠
+                TabView(selection: $selectedTab) {
 
-                HomeView().tag(0)
-                SellCarFlowView().tag(1)
-                SearchView().tag(2)
-//                ChatListView().tag(3)
-                
-               // ChatListView에 currentUserId 전달
-               if let user = session.user {
-                   ChatListView(currentUserId: user.id ?? " ")
-                       .tag(3)
-               } else {
-                   Text("로그인 필요")
-                       .tag(3)
-               }
-                
-                
-                MyPageView().tag(4)
-            }
-            
-            // 커스텀 탭바
-            VStack(spacing: 0) {
-                Divider()
-                    .background(Color.gray.opacity(0.3))
-                
-                HStack(spacing: 5) {
-                    bottomBarItem(icon: "Home", title: "내차사기", index: 0)
-                    bottomBarItem(icon: "Car", title: "내차팔기", index: 1)
-                    bottomBarItem(icon: "Search", title: "검색", index: 2)
-                    bottomBarItem(icon: "Chat", title: "채팅", index: 3)
-                    bottomBarItem(icon: "User", title: "마이", index: 4)
+                    HomeView().tag(0)
+                    SellCarFlowView().tag(1)
+                    SearchView().tag(2)
+                    
+                   // ChatListView에 currentUserId 전달
+                    if let user = session.user {
+                       ChatListView(currentUserId: user.id ?? " ")
+                           .tag(3)
+                    } else {
+                       Color.clear.tag(3)
+                    }
+                    if let _ = session.user {
+                        MyPageView().tag(4)
+                    } else {
+                        Color.clear.tag(4)
+                    }
+                   
                 }
-                .padding(.top, 10)
-                .padding(.horizontal)
-                .padding(.bottom, -14) // 화면 최하단에서 10 내려옴
-                .background(Color.white)
+                
+                // 커스텀 탭바
+                VStack(spacing: 0) {
+                    Divider()
+                        .background(Color.gray.opacity(0.3))
+                    
+                    HStack(spacing: 5) {
+                        bottomBarItem(icon: "Home", title: "내차사기", index: 0)
+                        bottomBarItem(icon: "Car", title: "내차팔기", index: 1)
+                        bottomBarItem(icon: "Search", title: "검색", index: 2)
+                        bottomBarItem(icon: "Chat", title: "채팅", index: 3,requiresLogin: true)
+                        bottomBarItem(icon: "User", title: "마이", index: 4,requiresLogin: true)
+                    }
+                    .padding(.top, 10)
+                    .padding(.horizontal)
+                    .padding(.bottom, -14) // 화면 최하단에서 10 내려옴
+                    .background(Color.white)
+                }
+            }
+            .ignoresSafeArea(.keyboard, edges: .bottom) // 키보드 뜰 때만 safe area 무시
+            .navigationDestination(isPresented: $navigateToLogin){
+                LoginView()
+            }
+            //모달
+            .overlay{
+                if showLoginModal {
+                    Color.black.opacity(0.4).ignoresSafeArea()
+                    ConfirmModalView(
+                        message: "로그인 이후 사용 가능합니다.",
+                        confirmTitle: "로그인",
+                        cancelTitle: "취소",
+                        onConfirm: {
+                            showLoginModal = false
+                            navigateToLogin = true
+                        },
+                        onCancel: {
+                            showLoginModal = false
+                        }
+                    )
+                    .background(Color.clear) // 배경 투명
+                    .transition(.opacity) // 부드럽게 등장
+                    .animation(.easeInOut, value: showLoginModal)
+                }
             }
         }
-        .ignoresSafeArea(.keyboard, edges: .bottom) // 키보드 뜰 때만 safe area 무시
+        
     }
     
     @ViewBuilder
-    private func bottomBarItem(icon: String, title: String, index: Int) -> some View {
+    private func bottomBarItem(icon: String, title: String, index: Int,requiresLogin: Bool = false) -> some View {
         Button {
-            withAnimation(.spring()) {
-                selectedTab = index
+            if requiresLogin && session.user == nil {
+                // 로그인 필요 → 모달 표시
+                showLoginModal = true
+            } else {
+                withAnimation(.spring()) {
+                    selectedTab = index
+                }
             }
         } label: {
             VStack {

--- a/Mocar-iOS/Shared/Components/Modal/ConfirmModalView.swift
+++ b/Mocar-iOS/Shared/Components/Modal/ConfirmModalView.swift
@@ -43,6 +43,8 @@ struct ConfirmModalView: View {
         .background(Color.white)
         .cornerRadius(12)
         .padding(.horizontal, 40)
+        
+        
     }
 }
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #39 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 바텀바가 로그인 여부와 상관없이 항상 노출되도록 변경
- 로그인하지 않은 상태에서 바텀바의 마이페이지/채팅 탭 클릭 시 "로그인 필요" 모달창 표시
- 모달창에서 
  - 확인(로그인) 버튼 → 로그인 페이지 이동
  - 취소 버튼 → 모달 닫기
- `LoginView` 내부의 불필요한 `NavigationStack` 제거 (기존 BottomBar의 NavigationStack과 중복 방지)

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

