### PR TITLE
feat/#48 비밀번호 분실 시 재설정 기능 구현

### DIFF
--- a/Mocar-iOS/Features/Auth/Views/LoginView.swift
+++ b/Mocar-iOS/Features/Auth/Views/LoginView.swift
@@ -38,7 +38,6 @@ struct LoginView: View {
                     .background(Color.backgroundGray100)
                 
 
-                
                 Text("로그인")
                     .font(.system(size: 30, weight: .semibold, design: .default))
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -123,10 +122,10 @@ struct LoginView: View {
                         Toggle("로그인 상태 유지", isOn: $keepLoggedIn)
                             .toggleStyle(CheckboxToggleStyle())
                         Spacer()
-                        Button("비밀번호 재설정") {
-                            // 비밀번호 재설정 액션
-                        }
-                        .foregroundColor(.blue)
+                        
+                        NavigationLink("비밀번호를 잃어버리셨나요? ", destination: ResetPasswordView())
+                            .foregroundColor(.blue)
+                        
                     }
                     .font(.system(size: 14, weight: .regular, design: .default))
                     .padding(.top, 6)

--- a/Mocar-iOS/Features/Auth/Views/ResetPasswordView.swift
+++ b/Mocar-iOS/Features/Auth/Views/ResetPasswordView.swift
@@ -1,0 +1,90 @@
+//
+//  ResetPasswordView.swift
+//  Mocar-iOS
+//
+//  Created by Admin on 9/23/25.
+//
+
+import SwiftUI
+import FirebaseAuth
+
+
+struct ResetPasswordView: View {
+    @State private var email: String = ""
+    @State private var message: String?
+    @Environment(\.dismiss) private var dismiss   // 뒤로가기용
+
+    var body: some View {
+        ZStack {
+          // 전체 배경색
+          Color.backgroundGray100
+              .ignoresSafeArea()
+
+          VStack(spacing: 20) {
+              TopBar(style: .RestPwd)
+                  .padding(.top)   // 안전 영역 고려해서 위쪽 붙이기
+                  .padding(.leading, 5)
+              Spacer().frame(height: 10)
+
+              // 본문
+              Text("비밀번호 재설정")
+                  .font(.system(size: 30, weight: .semibold))
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.horizontal)
+
+              
+              Spacer().frame(height: 30)
+              
+              TextField("이메일 주소 입력", text: $email)
+                  .keyboardType(.emailAddress)
+                  .textInputAutocapitalization(.never)
+                  .padding()
+                  .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.gray, lineWidth: 1)
+                  )
+                  .background(Color(.white))
+                  .padding(.horizontal)
+              
+              
+              Button(action: resetPassword) {
+                  Text("비밀번호 재설정 메일 보내기")
+                      .frame(maxWidth: .infinity)
+                      .padding()
+                      .background(Color.keyColorBlue)
+                      .foregroundColor(.white)
+                      .cornerRadius(8)
+                      .padding(.horizontal)
+              }
+
+              if let message = message {
+                  Text(message)
+                      .foregroundColor(.gray)
+                      .padding()
+              }
+
+              Spacer()
+          }
+      }
+      .navigationBarBackButtonHidden(true) // 기본 back 버튼 숨기기
+  }
+
+    private func resetPassword() {
+        guard !email.isEmpty else {
+            message = "이메일을 입력해주세요."
+            return
+        }
+
+        Auth.auth().sendPasswordReset(withEmail: email) { error in
+            if let error = error {
+                message = "에러: \(error.localizedDescription)"
+            } else {
+                message = "비밀번호 재설정 메일을 보냈습니다."
+            }
+        }
+    }
+}
+
+#Preview {
+    ResetPasswordView()
+}

--- a/Mocar-iOS/Shared/Components/Layout/TopBar.swift
+++ b/Mocar-iOS/Shared/Components/Layout/TopBar.swift
@@ -14,6 +14,7 @@ enum TopBarStyle{
     case listing(title: String)     // 뒤로가기 + 타이틀
     case MyPage(title: String)      // 뒤로가기 + 타이틀
     case Mylistings(title: String)  // 뒤로가기 + 왼쪽 타이틀
+    case RestPwd  // 뒤로가기 + 왼쪽 로고
     //case chat(title: String)   // 뒤로가기 + 채팅방 이름
 }
 
@@ -97,17 +98,21 @@ struct TopBar: View {
                         
                     }
                 }
-//                ZStack{
-//                    HStack {
-//                        BackButton()
-//                            .padding(.leading, 5)
-//                        Spacer()
-//                    }
-//                    Text(title)
-//                        .font(.system(size: 18, weight: .semibold, design: .default))
-//                }
-                
-            
+
+            case .RestPwd:
+                ZStack{
+                    BackButton()
+                        .padding(.leading, 3)
+                    HStack {
+                        Image("logo")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: 150)
+                            .padding(.leading, 40)
+                        Spacer()
+                        
+                    }
+                }
             }
         }
         //.padding(.horizontal, 16)   // 좌우 여백


### PR DESCRIPTION
## 📣 Related Issue

- close #48 

## 📝 Summary

- 로그인 화면에서 '비밀번호를 잃어버리셨나요?'를 선택하여 비밀번호 재설정 진행
- 사용자가 비밀번호를 분실했을 경우, 회원가입 시 입력한 이메일로 비밀번호 재설정 메일을 전송하는 기능을 추가
- Firebase Authentication의 sendPasswordResetEmail 메서드를 활용하여 간단히 구현
- 사용자가 이메일 내 링크를 클릭하면 새 비밀번호를 설정할 수 있으며, 이후 앱에서 해당 비밀번호로 로그인
